### PR TITLE
API improvements for integration in hackathon

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,99 +1,166 @@
-# Public Badge Grant API
+# BadgeFed Public API Documentation
 
-This API allows external systems to grant badges to recipients programmatically.
+## Overview
+
+The BadgeFed Public API allows external applications to programmatically grant badges to recipients. All API endpoints are under the `/api/badges` base path.
+
+## Authentication
+
+All protected endpoints require an **API key**. The key can be provided in one of two ways:
+
+| Method | Location | Example |
+|--------|----------|---------|
+| **Header** (recommended) | `X-ApiKey` request header | `X-ApiKey: your-api-key-here` |
+| **Query parameter** | `apiKey` query string | `/api/badges/grant?apiKey=your-api-key-here` |
+
+> **Note:** API keys are tied to active user accounts. There is currently no admin portal UI for managing API keys. You must set them directly in the database.
+
+#### Setting an API Key via SQL
+
+Generate a secure random key and assign it to a user:
+
+```sql
+-- Set an API key for a specific user by email
+UPDATE Users SET ApiKey = 'your-secure-api-key-here' WHERE Email = 'user@example.com';
+```
+
+> **Tip:** Use a cryptographically random string for the key (e.g., a UUID or a 32+ character random hex string). For example on Linux/macOS: `openssl rand -hex 32`
+
+---
 
 ## Endpoints
 
-### Grant Badge
-`POST /api/badges/grant`
+### List All Badges
 
-Grant a badge to a recipient.
+Retrieve all active badge definitions owned by the authenticated user.
 
-#### Request Body
-```json
-{
-  "badgeId": 123,
-  "profileUri": "https://mastodon.social/@username",
-  "name": "John Doe",
-  "email": "john@example.com",
-  "evidence": "Completed advanced training course"
-}
+```
+GET /api/badges
 ```
 
-#### Fields
-- `badgeId` (required): The ID of the badge to grant
-- `profileUri` (optional): Profile URI of the recipient (either this or email must be provided)
-- `name` (optional): Name of the recipient
-- `email` (optional): Email of the recipient (either this or profileUri must be provided)
-- `evidence` (optional): Evidence or reason for granting the badge
+**Authentication:** Required
 
-#### Success Response (200 OK)
+#### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `X-ApiKey` | Yes* | Your API key (*or use `apiKey` query param) |
+
+#### Example Request
+
+```bash
+curl https://your-instance.example.com/api/badges \
+  -H "X-ApiKey: your-api-key-here"
+```
+
+#### Success Response
+
+**Status:** `200 OK`
+
 ```json
 {
   "success": true,
-  "message": "Badge Example Badge granted successfully.",
-  "acceptUrl": "https://yourdomain.com/accept/456?key=abc123",
-  "badgeRecord": {
-    "id": 456,
-    "title": "Example Badge",
-    "issuedBy": "https://yourdomain.com/actors/yourdomain.com/issuer",
-    "issuedOn": "2025-09-05T10:30:00Z",
-    "issuedToName": "John Doe",
-    "issuedToSubjectUri": "https://mastodon.social/@username",
-    "earningCriteria": "Completed advanced training course"
-  }
+  "count": 2,
+  "badges": [
+    {
+      "id": 1,
+      "title": "Advanced Training",
+      "description": "Awarded for completing advanced training",
+      "badgeType": "Badge",
+      "earningCriteria": "Complete the advanced training course",
+      "image": "https://your-instance.example.com/badge-image/1",
+      "imageAltText": "Advanced Training Badge",
+      "hashtags": "#training #advanced",
+      "infoUri": "https://example.com/training",
+      "isCertificate": false,
+      "issuer": {
+        "id": 1,
+        "fullName": "My Organization",
+        "username": "org",
+        "domain": "your-instance.example.com"
+      }
+    }
+  ]
 }
 ```
 
 #### Error Responses
 
-**400 Bad Request** - Invalid request
-```json
-{
-  "error": "Either ProfileUri or Email must be provided"
-}
+| Status | Condition | Example Body |
+|--------|-----------|------|
+| `401 Unauthorized` | Missing API key | `{ "error": "API key is required. Provide it via X-ApiKey header or apiKey query parameter." }` |
+| `401 Unauthorized` | Invalid API key | `{ "error": "Invalid API key." }` |
+
+---
+
+### Grant a Badge
+
+Award a badge to a recipient by profile URI or email.
+
+```
+POST /api/badges/grant
 ```
 
-**404 Not Found** - Badge not found
-```json
-{
-  "error": "Badge with ID 123 not found."
-}
-```
+**Authentication:** Required
 
-**409 Conflict** - Badge already granted
-```json
-{
-  "error": "Badge Example Badge has already been granted to this recipient."
-}
-```
+#### Request Headers
 
-## Usage Examples
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Content-Type` | Yes | Must be `application/json` |
+| `X-ApiKey` | Yes* | Your API key (*or use `apiKey` query param) |
 
-### Using curl
+#### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `badgeId` | `integer` | **Yes** | ID of the badge to grant. Must be greater than 0. |
+| `profileUri` | `string` | Conditional | ActivityPub profile URI of the recipient. Max 500 characters. **Either `profileUri` or `email` must be provided.** |
+| `name` | `string` | No | Display name of the recipient. Max 200 characters. |
+| `email` | `string` | Conditional | Email address of the recipient. Max 254 characters. **Either `profileUri` or `email` must be provided.** |
+| `evidence` | `string` | No | Evidence or reason for granting the badge. Max 2000 characters. If omitted, the badge definition's default earning criteria is used. |
+
+#### Example Request (curl)
+
 ```bash
-curl -X POST https://yourdomain.com/api/badges/grant \
+curl -X POST https://your-instance.example.com/api/badges/grant \
   -H "Content-Type: application/json" \
+  -H "X-ApiKey: your-api-key-here" \
   -d '{
-    "badgeId": 123,
-    "profileUri": "https://mastodon.social/@username",
-    "name": "John Doe",
-    "evidence": "Completed advanced training course"
+    "badgeId": 1,
+    "profileUri": "https://mastodon.social/@recipient",
+    "name": "Jane Doe",
+    "evidence": "Completed the advanced training course"
   }'
 ```
 
-### Using JavaScript fetch
+#### Example Request (with email)
+
+```bash
+curl -X POST https://your-instance.example.com/api/badges/grant \
+  -H "Content-Type: application/json" \
+  -H "X-ApiKey: your-api-key-here" \
+  -d '{
+    "badgeId": 1,
+    "email": "jane@example.com",
+    "name": "Jane Doe"
+  }'
+```
+
+#### Example Request (JavaScript fetch)
+
 ```javascript
-const response = await fetch('/api/badges/grant', {
+const response = await fetch('https://your-instance.example.com/api/badges/grant', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
+    'X-ApiKey': 'your-api-key-here',
   },
   body: JSON.stringify({
-    badgeId: 123,
-    profileUri: 'https://mastodon.social/@username',
-    name: 'John Doe',
-    evidence: 'Completed advanced training course'
+    badgeId: 1,
+    profileUri: 'https://mastodon.social/@recipient',
+    name: 'Jane Doe',
+    evidence: 'Completed the advanced training course'
   })
 });
 
@@ -105,17 +172,243 @@ if (result.success) {
 }
 ```
 
+#### Success Response
+
+**Status:** `200 OK`
+
+```json
+{
+  "success": true,
+  "message": "Badge granted successfully",
+  "acceptUrl": "https://your-instance.example.com/accept/grant/42/abc123",
+  "badgeRecord": {
+    "id": 42,
+    "title": "Advanced Training",
+    "issuedBy": "https://your-instance.example.com/actor/admin",
+    "issuedOn": "2026-03-12T10:30:00Z",
+    "issuedToName": "Jane Doe",
+    "issuedToSubjectUri": "https://mastodon.social/@recipient",
+    "earningCriteria": "Completed the advanced training course"
+  }
+}
+```
+
+The `acceptUrl` is a link the recipient can visit to accept the badge. Share this URL with them directly or the system will notify them via ActivityPub if applicable.
+
+> **Note:** If the same badge has already been granted to the same recipient and is still pending acceptance, the API will return the existing `acceptUrl` without creating a duplicate grant.
+
+#### Error Responses
+
+| Status | Condition | Example Body |
+|--------|-----------|--------------|
+| `400 Bad Request` | Missing or invalid fields | `{ "error": "BadgeId is required and must be greater than 0" }` |
+| `400 Bad Request` | No recipient identifier | `{ "error": "Either ProfileUri or Email must be provided" }` |
+| `400 Bad Request` | Invalid email format | `{ "error": "Invalid email format" }` |
+| `400 Bad Request` | Invalid URL format | `{ "error": "Invalid ProfileUri format" }` |
+| `401 Unauthorized` | Missing API key | `{ "error": "API key is required. Provide it via X-ApiKey header or apiKey query parameter." }` |
+| `401 Unauthorized` | Invalid API key | `{ "error": "Invalid API key." }` |
+| `404 Not Found` | Badge ID doesn't exist | `{ "error": "Badge not found" }` |
+| `409 Conflict` | Badge already accepted | `{ "error": "This badge has already been granted to this recipient" }` |
+
+---
+
+### Get Grant Status
+
+Retrieve the status of a badge grant by its NoteId. Returns limited information: the recipient's profile URI, badge ID, and current status. Only grants for badges owned by the authenticated user are accessible.
+
+```
+GET /api/badges/grant/{noteId}/status
+```
+
+**Authentication:** Required (scoped to badges owned by the authenticated user)
+
+#### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `X-ApiKey` | Yes* | Your API key (*or use `apiKey` query param) |
+
+#### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `noteId` | `string` | The NoteId of the badge grant. Can be a full ActivityPub URL or the trailing ID segment. |
+
+#### Example Request
+
+```bash
+curl https://your-instance.example.com/api/badges/grant/abc123/status \
+  -H "X-ApiKey: your-api-key-here"
+```
+
+#### Success Response
+
+**Status:** `200 OK`
+
+```json
+{
+  "success": true,
+  "noteId": "https://your-instance.example.com/actor/org/statuses/abc123",
+  "profileUri": "https://mastodon.social/@recipient",
+  "badgeId": 1,
+  "status": "accepted"
+}
+```
+
+Possible `status` values:
+
+| Value | Description |
+|-------|-------------|
+| `pending` | Badge has been granted but not yet accepted by the recipient |
+| `accepted` | Badge has been accepted but not yet processed |
+| `processed` | Badge has been accepted and fully processed (fingerprint generated) |
+| `external` | Badge originates from an external source |
+
+> **Note:** Revoked grants are excluded and will return a `404` response.
+
+#### Error Responses
+
+| Status | Condition | Example Body |
+|--------|-----------|------|
+| `401 Unauthorized` | Missing API key | `{ "error": "API key is required. Provide it via X-ApiKey header or apiKey query parameter." }` |
+| `401 Unauthorized` | Invalid API key | `{ "error": "Invalid API key." }` |
+| `404 Not Found` | Grant not found, revoked, or not owned by user | `{ "error": "Grant not found." }` |
+
+---
+
+### Get Badge Information
+
+Retrieve detailed information about a specific badge definition. Only returns badges owned by the authenticated user.
+
+```
+GET /api/badges/{badgeId}
+```
+
+**Authentication:** Required
+
+#### Request Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `X-ApiKey` | Yes* | Your API key (*or use `apiKey` query param) |
+
+#### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `badgeId` | `integer` | The ID of the badge to look up |
+
+#### Example Request
+
+```bash
+curl https://your-instance.example.com/api/badges/1 \
+  -H "X-ApiKey: your-api-key-here"
+```
+
+#### Success Response
+
+**Status:** `200 OK`
+
+```json
+{
+  "success": true,
+  "badge": {
+    "id": 1,
+    "title": "Advanced Training",
+    "description": "Awarded for completing advanced training",
+    "badgeType": "Badge",
+    "earningCriteria": "Complete the advanced training course",
+    "image": "https://your-instance.example.com/badge-image/1",
+    "imageAltText": "Advanced Training Badge",
+    "hashtags": "#training #advanced",
+    "infoUri": "https://example.com/training",
+    "isCertificate": false,
+    "issuer": {
+      "id": 1,
+      "fullName": "My Organization",
+      "username": "org",
+      "domain": "your-instance.example.com"
+    }
+  }
+}
+```
+
+#### Error Responses
+
+| Status | Condition | Example Body |
+|--------|-----------|------|
+| `401 Unauthorized` | Missing API key | `{ "error": "API key is required. Provide it via X-ApiKey header or apiKey query parameter." }` |
+| `401 Unauthorized` | Invalid API key | `{ "error": "Invalid API key." }` |
+| `404 Not Found` | Badge not found or not owned by user | `{ "error": "Badge not found or not authorized." }` |
+
+---
+
+## Common Patterns
+
+### Granting a Badge via ActivityPub Profile
+
+When the recipient has a Fediverse/ActivityPub profile, use `profileUri`:
+
+```json
+{
+  "badgeId": 5,
+  "profileUri": "https://mastodon.social/@user",
+  "name": "User Name",
+  "evidence": "Outstanding contribution to the project"
+}
+```
+
+### Granting a Badge via Email
+
+When the recipient doesn't have a Fediverse profile, use `email`:
+
+```json
+{
+  "badgeId": 5,
+  "email": "user@example.com",
+  "name": "User Name"
+}
+```
+
+### Providing Both Identifiers
+
+You can provide both `profileUri` and `email` if available:
+
+```json
+{
+  "badgeId": 5,
+  "profileUri": "https://mastodon.social/@user",
+  "email": "user@example.com",
+  "name": "User Name",
+  "evidence": "Speaker at the 2026 conference"
+}
+```
+
+---
+
 ## Integration Notes
 
 1. The API returns an `acceptUrl` that the recipient can use to accept the badge
 2. You can provide either `profileUri` or `email` (or both) to identify the recipient
 3. If `evidence` is not provided, the badge's default earning criteria will be used
-4. The API prevents duplicate grants to the same recipient for the same badge
-5. Currently, no authentication is required (this may change in future versions)
+4. The API prevents duplicate grants — if a pending grant already exists, the existing `acceptUrl` is returned
+5. All protected endpoints require an API key via `X-ApiKey` header or `apiKey` query parameter
 
 ## Badge Record Flow
 
-1. Call the grant API with recipient information
+1. Call the grant API with recipient information and your API key
 2. System creates a badge record with an accept key
-3. Recipient visits the accept URL to claim the badge
-4. Once accepted, the badge becomes part of the recipient's public profile
+3. Recipient is notified via ActivityPub (if applicable) or you share the `acceptUrl` directly
+4. Recipient visits the accept URL to claim the badge
+5. Once accepted, the badge becomes part of the recipient's public profile
+
+---
+
+## Field Constraints Summary
+
+| Field | Max Length | Format |
+|-------|-----------|--------|
+| `profileUri` | 500 | Valid HTTP/HTTPS URL |
+| `name` | 200 | Free text |
+| `email` | 254 | Valid email address |
+| `evidence` | 2000 | Free text (Optional) |

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,121 @@
+# Public Badge Grant API
+
+This API allows external systems to grant badges to recipients programmatically.
+
+## Endpoints
+
+### Grant Badge
+`POST /api/badges/grant`
+
+Grant a badge to a recipient.
+
+#### Request Body
+```json
+{
+  "badgeId": 123,
+  "profileUri": "https://mastodon.social/@username",
+  "name": "John Doe",
+  "email": "john@example.com",
+  "evidence": "Completed advanced training course"
+}
+```
+
+#### Fields
+- `badgeId` (required): The ID of the badge to grant
+- `profileUri` (optional): Profile URI of the recipient (either this or email must be provided)
+- `name` (optional): Name of the recipient
+- `email` (optional): Email of the recipient (either this or profileUri must be provided)
+- `evidence` (optional): Evidence or reason for granting the badge
+
+#### Success Response (200 OK)
+```json
+{
+  "success": true,
+  "message": "Badge Example Badge granted successfully.",
+  "acceptUrl": "https://yourdomain.com/accept/456?key=abc123",
+  "badgeRecord": {
+    "id": 456,
+    "title": "Example Badge",
+    "issuedBy": "https://yourdomain.com/actors/yourdomain.com/issuer",
+    "issuedOn": "2025-09-05T10:30:00Z",
+    "issuedToName": "John Doe",
+    "issuedToSubjectUri": "https://mastodon.social/@username",
+    "earningCriteria": "Completed advanced training course"
+  }
+}
+```
+
+#### Error Responses
+
+**400 Bad Request** - Invalid request
+```json
+{
+  "error": "Either ProfileUri or Email must be provided"
+}
+```
+
+**404 Not Found** - Badge not found
+```json
+{
+  "error": "Badge with ID 123 not found."
+}
+```
+
+**409 Conflict** - Badge already granted
+```json
+{
+  "error": "Badge Example Badge has already been granted to this recipient."
+}
+```
+
+## Usage Examples
+
+### Using curl
+```bash
+curl -X POST https://yourdomain.com/api/badges/grant \
+  -H "Content-Type: application/json" \
+  -d '{
+    "badgeId": 123,
+    "profileUri": "https://mastodon.social/@username",
+    "name": "John Doe",
+    "evidence": "Completed advanced training course"
+  }'
+```
+
+### Using JavaScript fetch
+```javascript
+const response = await fetch('/api/badges/grant', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    badgeId: 123,
+    profileUri: 'https://mastodon.social/@username',
+    name: 'John Doe',
+    evidence: 'Completed advanced training course'
+  })
+});
+
+const result = await response.json();
+if (result.success) {
+  console.log('Badge granted! Accept URL:', result.acceptUrl);
+} else {
+  console.error('Error:', result.error);
+}
+```
+
+## Integration Notes
+
+1. The API returns an `acceptUrl` that the recipient can use to accept the badge
+2. You can provide either `profileUri` or `email` (or both) to identify the recipient
+3. If `evidence` is not provided, the badge's default earning criteria will be used
+4. The API prevents duplicate grants to the same recipient for the same badge
+5. Currently, no authentication is required (this may change in future versions)
+
+## Badge Record Flow
+
+1. Call the grant API with recipient information
+2. System creates a badge record with an accept key
+3. Recipient visits the accept URL to claim the badge
+4. Once accepted, the badge becomes part of the recipient's public profile

--- a/src/BadgeFed/Controllers/PublicBadgeApiController.cs
+++ b/src/BadgeFed/Controllers/PublicBadgeApiController.cs
@@ -167,17 +167,172 @@ namespace BadgeFed.Controllers
         }
 
         /// <summary>
+        /// Get the status of a badge grant by its NoteId
+        /// </summary>
+        /// <param name="noteId">The NoteId (grant ID) of the badge record</param>
+        /// <returns>Grant status with limited information</returns>
+        [HttpGet("grant/{noteId}/status")]
+        [ProducesResponseType(typeof(object), 200)]
+        [ProducesResponseType(typeof(object), 401)]
+        [ProducesResponseType(typeof(object), 404)]
+        public IActionResult GetGrantStatus(string noteId)
+        {
+            var apiKey = GetApiKeyFromRequest();
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                return Unauthorized(new { error = "API key is required. Provide it via X-ApiKey header or apiKey query parameter." });
+            }
+
+            var user = _localDbService.ValidateApiKey(apiKey);
+            if (user == null)
+            {
+                _logger.LogWarning("Invalid API key attempt: {ApiKey}", apiKey);
+                return Unauthorized(new { error = "Invalid API key." });
+            }
+
+            _logger.LogInformation("API request to get grant status for NoteId: {NoteId} by user: {UserId}", noteId, user.Id);
+
+            var record = _localDbService.GetGrantByNoteId(noteId);
+
+            if (record == null)
+            {
+                return NotFound(new { error = "Grant not found." });
+            }
+
+            // Verify the authenticated user owns the badge associated with this grant
+            if (record.Badge?.Id > 0)
+            {
+                var ownershipFilter = $"a.OwnerId = '{user.GroupId}' AND b.Id = {record.Badge.Id}";
+                var ownedBadges = _localDbService.GetAllBadgeDefinitions(true, ownershipFilter);
+                if (!ownedBadges.Any())
+                {
+                    return NotFound(new { error = "Grant not found." });
+                }
+            }
+
+            return Ok(new
+            {
+                success = true,
+                noteId = record.NoteId,
+                profileUri = record.IssuedToSubjectUri,
+                badgeId = record.Badge?.Id,
+                status = record.Status
+            });
+        }
+
+        /// <summary>
+        /// List all active badges owned by the authenticated user
+        /// </summary>
+        /// <returns>List of badge definitions</returns>
+        [HttpGet]
+        [ProducesResponseType(typeof(object), 200)]
+        [ProducesResponseType(typeof(object), 401)]
+        public IActionResult ListBadges()
+        {
+            var apiKey = GetApiKeyFromRequest();
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                return Unauthorized(new { error = "API key is required. Provide it via X-ApiKey header or apiKey query parameter." });
+            }
+
+            var user = _localDbService.ValidateApiKey(apiKey);
+            if (user == null)
+            {
+                _logger.LogWarning("Invalid API key attempt: {ApiKey}", apiKey);
+                return Unauthorized(new { error = "Invalid API key." });
+            }
+
+            _logger.LogInformation("API request to list badges for user: {UserId} ({UserEmail})", user.Id, user.Email);
+
+            var filter = $"a.OwnerId = '{user.GroupId}'";
+            var badges = _localDbService.GetAllBadgeDefinitions(true, filter);
+
+            return Ok(new
+            {
+                success = true,
+                count = badges.Count,
+                badges = badges.Select(b => new
+                {
+                    id = b.Id,
+                    title = b.Title,
+                    description = b.Description,
+                    badgeType = b.BadgeType,
+                    earningCriteria = b.EarningCriteria,
+                    image = b.Image,
+                    imageAltText = b.ImageAltText,
+                    hashtags = b.Hashtags,
+                    infoUri = b.InfoUri,
+                    isCertificate = b.IsCertificate,
+                    issuer = b.Issuer != null ? new
+                    {
+                        id = b.Issuer.Id,
+                        fullName = b.Issuer.FullName,
+                        username = b.Issuer.Username,
+                        domain = b.Issuer.Domain
+                    } : null
+                })
+            });
+        }
+
+        /// <summary>
         /// Get badge information
         /// </summary>
         /// <param name="badgeId">Badge ID</param>
         /// <returns>Badge information</returns>
         [HttpGet("{badgeId}")]
+        [ProducesResponseType(typeof(object), 200)]
+        [ProducesResponseType(typeof(object), 401)]
+        [ProducesResponseType(typeof(object), 404)]
         public IActionResult GetBadge(long badgeId)
         {
+            var apiKey = GetApiKeyFromRequest();
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                return Unauthorized(new { error = "API key is required. Provide it via X-ApiKey header or apiKey query parameter." });
+            }
+
+            var user = _localDbService.ValidateApiKey(apiKey);
+            if (user == null)
+            {
+                _logger.LogWarning("Invalid API key attempt: {ApiKey}", apiKey);
+                return Unauthorized(new { error = "Invalid API key." });
+            }
+
             _logger.LogInformation("[{RequestHost}] API request to get badge: {BadgeId}", Request.Host, badgeId);
-            // This would be handled by your existing LocalScopedDb service
-            // You might want to inject it here if needed for badge lookup
-            return Ok(new { message = "Badge lookup endpoint - implement as needed" });
+
+            var filter = $"a.OwnerId = '{user.GroupId}' AND b.Id = {badgeId}";
+            var badges = _localDbService.GetAllBadgeDefinitions(true, filter);
+            var badge = badges.FirstOrDefault();
+
+            if (badge == null)
+            {
+                return NotFound(new { error = "Badge not found or not authorized." });
+            }
+
+            return Ok(new
+            {
+                success = true,
+                badge = new
+                {
+                    id = badge.Id,
+                    title = badge.Title,
+                    description = badge.Description,
+                    badgeType = badge.BadgeType,
+                    earningCriteria = badge.EarningCriteria,
+                    image = badge.Image,
+                    imageAltText = badge.ImageAltText,
+                    hashtags = badge.Hashtags,
+                    infoUri = badge.InfoUri,
+                    isCertificate = badge.IsCertificate,
+                    issuer = badge.Issuer != null ? new
+                    {
+                        id = badge.Issuer.Id,
+                        fullName = badge.Issuer.FullName,
+                        username = badge.Issuer.Username,
+                        domain = badge.Issuer.Domain
+                    } : null
+                }
+            });
         }
     }
 

--- a/src/BadgeFed/Models/BadgeRecord.cs
+++ b/src/BadgeFed/Models/BadgeRecord.cs
@@ -115,5 +115,34 @@ namespace BadgeFed.Models
 
         [System.Text.Json.Serialization.JsonIgnore]
         public string Visibility { get; set; } = "Public";
+
+        [System.Text.Json.Serialization.JsonIgnore]
+        public string Status
+        {
+            get
+            {
+                return GetRecordStatus(this);
+            }
+        }
+
+        private string GetRecordStatus(BadgeRecord record)
+        {
+            if (record.IsExternal)
+            {
+                return "external";
+            }
+            else if (!string.IsNullOrEmpty(record.FingerPrint))
+            {
+                return "processed";
+            }
+            else if (record.AcceptedOn.HasValue)
+            {
+                return "accepted";
+            }
+            else
+            {
+                return "pending";
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request adds new authenticated API endpoints to the `PublicBadgeApiController` for badge and grant management, and introduces a computed `Status` property to the `BadgeRecord` model to standardize grant status reporting. 

- Updated `GetBadge` endpoint to require API key authentication and return detailed badge information only if the authenticated user owns the badge; returns appropriate error responses otherwise.
- Introduced a computed `Status` property to the `BadgeRecord` model, which derives the grant status based on properties such as `IsExternal`, `FingerPrint`, and `AcceptedOn`. This property is used in API responses for consistent status reporting.
- Added a few more endpoints